### PR TITLE
Possible improvements for TAXAassign

### DIFF
--- a/TAXAassign.sh
+++ b/TAXAassign.sh
@@ -103,8 +103,10 @@ Options:
 
 set -o errexit
 
+CURRENT_DIR=$(pwd)
+
 # = Parameters to set ============== #
-LOGFILE="`pwd`/TAXAassign.log" # Where to save the log
+LOGFILE="${CURRENT_DIR}/TAXAassign.log" # Where to save the log
 BLASTN_DIR="/home/opt/ncbi-blast-2.2.28+/bin"; # Path where blastn is installed
 BLASTDB_DIR="/home/opt/ncbi-blast-2.2.28+/db"; # Path where nt is installed
 FASTA_FILE=""   # This field should be empty
@@ -116,8 +118,6 @@ MINIMUM_QUERY_COVERAGE=97
 CONSENSUS_THRESHOLD=90
 TAXONOMIC_LEVELS_THRESHOLD=""
 # =/Parameters to set ============== #
-
-CURRENT_DIR=`pwd`
 
 # = Enable FP support ============== #
 # By default, there is limited capability in bash to handle floating point

--- a/TAXAassign.sh
+++ b/TAXAassign.sh
@@ -185,19 +185,13 @@ function check_prog() {
 }
 
 function skip_gen_file() {
-    if [ -f "$1" ] ; then
-        echo "true"
-    else
-        echo "false"
-    fi
+    # Is it a file?
+    [[ -f "$1" ]] && echo "true" || echo "false"
 }
 
 function skip_gen_dir() {
-    if [ -d "$1" ]; then
-        echo "true"
-    else
-        echo "false"
-    fi
+    # Is it a directory?
+    [[ -d "$1" ]] && echo "true" || echo "false"
 }
 
 function TAXAassign_print() {

--- a/TAXAassign.sh
+++ b/TAXAassign.sh
@@ -165,17 +165,6 @@ function ceil () {
 # =/Enable FP support ============== #
 
 
-# Create directories if they don't exist yet
-function create_dirs() {
-    local dir
-    for dir in "$@"
-    do
-        if [ ! -d "$dir" ]; then
-            mkdir "$dir"
-        fi
-    done
-}
-
 # Check if files exist
 function check_prog() {
     local prog

--- a/TAXAassign.sh
+++ b/TAXAassign.sh
@@ -83,7 +83,8 @@
 #            along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # **************************************************************/     
 
-HELPDOC="Script to annotate sequences at different taxonomic levels using  NCBI's taxonomy
+HELPDOC="
+Script to annotate sequences at different taxonomic levels using  NCBI's taxonomy
 
 Usage:
     bash `basename $0` -f <fasta_file.fasta> [options]
@@ -398,3 +399,4 @@ else
         TAXAassign_print "Sequences assigned at species level: $speciesLevelAssignments/$totalReads ($(float_eval "($speciesLevelAssignments / $totalReads) * 100")%)"
 fi
 
+exit 0

--- a/TAXAassign.sh
+++ b/TAXAassign.sh
@@ -233,19 +233,19 @@ while getopts ":phc:r:m:f:t:q:a:" opt ; do
 	        TAXONOMIC_LEVELS_THRESHOLD=$OPTARG
 	        ;;
         h)
-            echo "$HELPDOC"
+            echo "$HELPDOC" 1>&2
             exit 0
             ;;
         \?)
-            echo "$HELPDOC"
-            echo "Invalid option: -$OPTARG" >&2
+            echo "$HELPDOC" 1>&2
+            echo "Invalid option: -$OPTARG" 1>&2
             exit 1
             ;;
     esac
 done
 
 if [ -z $FASTA_FILE ] ; then
-        echo "$HELPDOC"
+        echo "$HELPDOC" 1>&2
         exit 1
 fi
 
@@ -259,20 +259,20 @@ TLTArray=($TAXONOMIC_LEVELS_THRESHOLD);
 IFS=$OIFS;
 
 if [ "${#TLTArray[@]}" != "6" ] ; then
-        echo "$HELPDOC"
+        echo "$HELPDOC" 1>&2
         exit 1
 fi
 
 for i in "${TLTArray[@]}" ; do
    if ! [[ $i =~ ^-?[0-9]+$ ]] ; then
-        echo "$HELPDOC"
+        echo "$HELPDOC" 1>&2
         exit 1
    fi
 done
 
 
 if ! [[ $MINIMUM_PERCENT_IDENT =~ ^-?[0-9]+$ ]] || ! [[ $NUMBER_OF_CORES =~ ^-?[0-9]+$ ]] || ! [[ $NUMBER_OF_REFERENCE_MATCHES =~ ^-?[0-9]+$ ]] || ! [[ $CONSENSUS_THRESHOLD =~ ^-?[0-9]+$ ]] || ! [[ $MINIMUM_QUERY_COVERAGE =~ ^-?[0-9]+$ ]]; then
-	echo "$HELPDOC"
+	echo "$HELPDOC" 1>&2
 	exit 1
 fi
 

--- a/TAXAassign.sh
+++ b/TAXAassign.sh
@@ -83,8 +83,7 @@
 #            along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # **************************************************************/     
 
-HELPDOC=$( cat <<EOF
-Script to annotate sequences at different taxonomic levels using  NCBI's taxonomy
+HELPDOC="Script to annotate sequences at different taxonomic levels using  NCBI's taxonomy
 
 Usage:
     bash `basename $0` -f <fasta_file.fasta> [options]
@@ -94,13 +93,12 @@ Options:
     -r Number of reference matches (Default: 10)
     -m Minimum percentage identity in blastn (Default: 97)
     -q Minimum query coverage in blastn (Default: 97)
-    -a Threshold at different taxonomic levels (Default:"-m,-m,-m,-m,-m,-m" where -m is the minimum percentage identity argument)
+    -a Threshold at different taxonomic levels (Default: \"-m,-m,-m,-m,-m,-m\" where -m is the minimum percentage identity argument)
        The order is as follows: Phylum,Class,Order,Family,Genus,Species
-       For example, -a "60,70,80,95,95,97"
+       For example, -a \"60,70,80,95,95,97\"
     -t Consensus threshold (Default: 90)
 
-EOF
-)
+"
 
 set -o errexit
 


### PR DESCRIPTION
Hi Umer,

here are some coding style or simplifications I suggest for the TAXAassign shell script. Several of the conditional loops you use could be replace with one-liners ( [[test]] || die). Some tests regarding the status of files (exists, is empty, etc), could also be simplified by using the new pattern substitutions in bash 4.0. But unfortunately, many computer still have bash 3.0 installed.

Best,
